### PR TITLE
Cache creation of letterMap

### DIFF
--- a/lib/dictionary.dart
+++ b/lib/dictionary.dart
@@ -13,6 +13,7 @@ final class Dictionary {
 
   static Future<Dictionary> init() async {
     final file = await rootBundle.loadString('assets/words.txt');
+    final letterMap = const EnglishAlphabet().letterMap;
     final iterable = file.split("\n").map(
           (key) => (
             key.toUpperCase(),
@@ -20,13 +21,8 @@ final class Dictionary {
               points: key
                   .toUpperCase()
                   .split("")
-                  .map(
-                    (letter) =>
-                        const EnglishAlphabet().letterMap[letter]!.points,
-                  )
-                  .reduce(
-                    (acc, points) => acc + points,
-                  ),
+                  .map((letter) => letterMap[letter]!.points)
+                  .reduce((acc, points) => acc + points),
             ),
           ),
         );


### PR DESCRIPTION
Because letterMap is a getter in the `Alphabet` class, it gets created every time that getter is called. Unfortunately in the current code it gets called very often inside of nested Iterable.map functions. This PR changes the code to create the letterMap once, which saves around 6500ms (6.5 seconds!) at runtime on my machine, from 8000ms to 1500ms. I first learned about this from [this tweet](https://twitter.com/SandroMaglione/status/1753783000368558563) (which BTW, the code shown doesn't compile and doesn't show the main culprit that takes up most of the time).